### PR TITLE
fix the type of the chooseFolder method (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ async function pickFolder() {
 
 Opens a system file picker dialog to select a folder.
 
-- **Returns:** Promise\<{ value: string }\> - A promise that resolves with the selected folder path.
+- **Returns:** Promise\<{ path: string }\> - A promise that resolves with the selected folder path.
 
 ## License
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,3 @@
 export interface FolderPickerPlugin {
-  chooseFolder(): Promise<{ value: string }>;
+  chooseFolder(): Promise<{ path: string }>;
 }


### PR DESCRIPTION
I guess my explanation of the problem wasn't clear enough. The problem was not in the readme, the problem was that the returned type does not correspond to the real value.

<img width="506" alt="image" src="https://github.com/user-attachments/assets/6cf6ba32-5d91-4079-bc7b-389285758564">

This is return result from the `chooseFolder` method